### PR TITLE
Add corretto jdk 21 and tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+ARG CORE_VERSION="latest"
+FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-base-build:${CORE_VERSION}
+
+ARG ARTIFACTORY_URL=""
+ENV ARTIFACTORY_URL=${ARTIFACTORY_URL}
+ARG ANT_VERSION="1.10.14"
+ARG IVY_VERSION="2.5.2"
+
+RUN dnf upgrade -y && \
+    dnf install -y \
+    java-21-amazon-corretto \
+    maven-amazon-corretto21.noarch && \
+    dnf clean all
+
+# Set home env vars
+ENV ANT_HOME /usr/lib/ant
+ENV IVY_HOME /usr/lib/ivy
+ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk
+
+# Download and extract Apache Ant
+RUN wget -O /tmp/apache-ant.tar.gz https://downloads.apache.org/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz && \
+    mkdir -p $ANT_HOME && \
+    tar -xzf /tmp/apache-ant.tar.gz -C $ANT_HOME --strip-components=1 && \
+    rm /tmp/apache-ant.tar.gz
+
+# Download and extract Apache Ivy and add to ant lib
+RUN wget -O /tmp/apache-ivy.tar.gz https://downloads.apache.org/ant/ivy/${IVY_VERSION}/apache-ivy-${IVY_VERSION}-bin.tar.gz && \
+    mkdir -p $IVY_HOME && \
+    tar -xzf /tmp/apache-ivy.tar.gz -C $IVY_HOME --strip-components=1 && \
+    rm /tmp/apache-ivy.tar.gz && \
+    cp /usr/lib/ivy/ivy-${IVY_VERSION}.jar /usr/lib/ant/lib/
+
+# Add ant to path
+ENV PATH $ANT_HOME/bin:$PATH
+
+COPY resources/configure-maven /usr/local/bin/configure-maven

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-# ci-corretto-jdk17-maven-build
-Image used for Amazon Corretto 17 Maven application builds
+ci-corretto-jdk-build
+Image used for Amazon Corretto application builds
+
+## Build ARGs
+
+The following Docker build arguments are supported
+
+| Argument        | Default                                                                   | Description                                          |
+| --------------- | ------------------------------------------------------------------------- | ---------------------------------------------------- |
+| ARTIFACTORY_URL |                                                                           | Artifactory URL used by the `configure-maven` script |
+
+## Building the image
+
+```sh
+docker build -t ci-corretto-jdk-build-21 -f ./Dockerfile .
+```
+
+## Running the image
+
+If you would like to run and connect to the image, you can do so by running the following:
+
+```sh
+docker run -it --rm ci-corretto-jdk-build-21 bash
+```
+
+## Building the source-code
+
+To mount a project into the container you can run the following:
+
+```sh
+# populate the placeholders below
+docker run -it --rm -v /Users/<username>/<path_to_repo>/<repo_name>:/<path_to_source-code> ci-corretto-jdk-build-21 bash

--- a/resources/configure-maven
+++ b/resources/configure-maven
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+BLUE='\033[1;34m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+print_info () {
+    printf "%sInfo: %s${1}\n" "${BLUE}" "${RESET}"
+}
+
+M2_HOME="${HOME}/.m2"
+mkdir -p "${M2_HOME}"
+
+M2_LOCAL_REPO="${PWD}/.m2/repository"
+
+mkdir -p "${M2_LOCAL_REPO}"
+
+cat > "${M2_HOME}"/settings.xml <<EOF
+<settings   xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <localRepository>${M2_LOCAL_REPO}</localRepository>
+
+    <mirrors>
+        <mirror>
+            <id>virtual-release</id>
+            <name>Artifactory</name>
+            <url>${ARTIFACTORY_URL}/virtual-release</url>
+            <mirrorOf>central</mirrorOf>
+        </mirror>
+    </mirrors>
+
+</settings>
+EOF
+
+print_info "Configured local mvn repository: [${BOLD}${M2_LOCAL_REPO}${RESET}]"


### PR DESCRIPTION
Create build image supporting ant and maven with java 21 jdk.

Tested through mounting and running Java-21 branch of psc-discrepancies api for maven.

develop branch of chips to run ant (failing build)